### PR TITLE
Be explicit about import from Term::ANSIColor

### DIFF
--- a/wordle.pl
+++ b/wordle.pl
@@ -9,7 +9,7 @@ BEGIN {  # attempt to get this to work on Windows Consoles
    }
    Win32::Console::ANSI->import;
 }
-use Term::ANSIColor;  # allow coloured terminal output
+use Term::ANSIColor qw( color );  # allow coloured terminal output
 
 my $wordLength=5;     # set number of letters 
 my $maxGuesses=6;     # set number of guesses 


### PR DESCRIPTION
This change makes it obvious where the color() function comes from and
it also doesn't import any other unneeded symbols from Term::ANSIColor.

The change was generated via App::perlimports
